### PR TITLE
Feature: reticker [1/2]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -5251,6 +5251,18 @@ public final class Settings {
          */
 
         /**
+         * reTicker Status
+         * @hide
+         */
+        public static final String RETICKER_STATUS = "reticker_status";
+
+        /**
+         * reTicker Colored
+         * @hide
+         */
+        public static final String RETICKER_COLORED = "reticker_colored";
+
+        /**
          * Keys we no longer back up under the current schema, but want to continue to
          * process when restoring historical backup datasets.
          *

--- a/packages/SystemUI/res/drawable/qs_alike_top.xml
+++ b/packages/SystemUI/res/drawable/qs_alike_top.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item>
+        <shape android:shape="oval"
+            xmlns:android="http://schemas.android.com/apk/res/android">
+            <corners android:radius="8dp"/>
+            <stroke android:width="0dp" android:color="?android:attr/colorAccent"/>
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="oval"
+            xmlns:android="http://schemas.android.com/apk/res/android">
+            <corners android:radius="8dp"/>
+            <stroke android:width="0dp" android:color="?android:attr/colorAccent"/>
+            <solid android:color="#15888888" />
+        </shape>
+    </item>
+</layer-list>

--- a/packages/SystemUI/res/drawable/reticker_background.xml
+++ b/packages/SystemUI/res/drawable/reticker_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape android:shape="rectangle"  xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/reticker_background_color" />
+    <corners android:radius="?android:attr/dialogCornerRadius" />
+</shape>

--- a/packages/SystemUI/res/layout/status_bar_expanded.xml
+++ b/packages/SystemUI/res/layout/status_bar_expanded.xml
@@ -25,6 +25,44 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@android:color/transparent">
+
+    <LinearLayout
+        android:id="@+id/ticker_comeback"
+        android:animateLayoutChanges="true"
+        android:elevation="100dp"
+        android:background="@drawable/reticker_background"
+        android:layout_marginTop="@dimen/status_bar_header_height_keyguard"
+        android:visibility="gone"
+        android:paddingBottom="4dp"
+        android:paddingTop="4dp"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginLeft="8dp"
+        android:layout_marginRight="8dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+        <ImageView
+            android:id="@+id/ticker_comeback_icon"
+            android:layout_gravity="center_vertical"
+            android:layout_marginLeft="12dp"
+            android:background="@drawable/qs_alike_top"
+            android:layout_width="16dp"
+            android:layout_height="16dp"/>
+        <TextView
+            android:id="@+id/ticker_content"
+            android:layout_marginLeft="8dp"
+            android:layout_marginRight="12dp"
+            android:layout_gravity="center_vertical"
+            android:singleLine="true"
+            android:ellipsize="marquee"
+            android:marqueeRepeatLimit="marquee_forever"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
+            android:scrollHorizontally="true"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/TextAppearance.Notifications.reTicker"/>
+    </LinearLayout>
+
     <ViewStub
         android:id="@+id/keyguard_qs_user_switch_stub"
         android:layout="@layout/keyguard_qs_user_switch"

--- a/packages/SystemUI/res/values-night/kscope_colors.xml
+++ b/packages/SystemUI/res/values-night/kscope_colors.xml
@@ -7,4 +7,6 @@
     <!-- QS Drag Handler -->
     <color name="kscope_qs_drag_handle_color">@android:color/system_neutral1_700</color>
 
+    <!-- reTicker Background Color -->
+    <color name="reticker_background_color">@android:color/system_neutral1_900</color>
 </resources>

--- a/packages/SystemUI/res/values/kscope_arrays.xml
+++ b/packages/SystemUI/res/values/kscope_arrays.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2022 Project Kaleidoscope
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<resources>
+    <!-- reTicker -->
+    <string-array name="app_exceptions" translatable="false">
+        <item>org.kde.kdeconnect_tp</item>
+        <item>#FF808080</item>
+        <item>com.instagram.android</item>
+        <item>#FF833AB4</item>
+        <item>com.google.android.dialer</item>
+        <item>#FF2162D7</item>
+        <item>com.google.android.youtube</item>
+        <item>#FFDE4B4B</item>
+    </string-array>
+</resources>

--- a/packages/SystemUI/res/values/kscope_colors.xml
+++ b/packages/SystemUI/res/values/kscope_colors.xml
@@ -7,4 +7,7 @@
     <!-- QS Drag Handler -->
     <color name="kscope_qs_drag_handle_color">@android:color/system_neutral1_200</color>
 
+    <!-- reTicker Background Color -->
+    <color name="reticker_background_color">@android:color/system_neutral1_50</color>
+
 </resources>

--- a/packages/SystemUI/res/values/kscope_styles.xml
+++ b/packages/SystemUI/res/values/kscope_styles.xml
@@ -24,4 +24,10 @@
         <item name="android:textSize">14sp</item>
         <item name="android:fontFamily">@*android:string/config_bodyFontFamily</item>
     </style>
+
+    <!-- reTicker -->
+    <style name="TextAppearance.Notifications.reTicker" parent="@*android:style/TextAppearance.StatusBar.Icon">
+        <item name="android:textSize">14dp</item>
+        <item name="android:fontFamily">@*android:string/config_bodyFontFamily</item>
+    </style>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/RetickerAnimations.java
+++ b/packages/SystemUI/src/com/android/systemui/RetickerAnimations.java
@@ -1,0 +1,53 @@
+package com.android.systemui;
+
+import android.animation.Animator;
+import android.animation.ObjectAnimator;
+import android.view.animation.BounceInterpolator;
+import android.view.View;
+
+public class RetickerAnimations {
+
+    static boolean mIsAnimatingTicker;
+
+    public static void doBounceAnimationIn(View targetView) {
+        ObjectAnimator animator = ObjectAnimator.ofFloat(targetView, "translationY", -100, 0, 0);
+        ObjectAnimator animator2 = ObjectAnimator.ofFloat(targetView, "translationX", 0, 17, 0);
+        animator.setInterpolator(new BounceInterpolator());
+        animator2.setInterpolator(new BounceInterpolator());
+        animator.setDuration(500);
+        animator2.setStartDelay(500);
+        animator2.setDuration(500);
+        animator.start();
+        animator2.start();
+        targetView.setVisibility(View.VISIBLE);
+    }
+
+    public static void doBounceAnimationOut(View targetView, View notificationStackScroller) {
+        ObjectAnimator animator = ObjectAnimator.ofFloat(targetView, "translationY", 0, -1000, -1000);
+        animator.setInterpolator(new BounceInterpolator());
+        animator.setDuration(350);
+        animator.start();
+        animator.addListener(new Animator.AnimatorListener() {
+            @Override
+            public void onAnimationStart(Animator animation) {
+            }
+            @Override
+            public void onAnimationRepeat(Animator animation) {
+            }
+            @Override
+            public void onAnimationEnd(Animator animation) {
+                notificationStackScroller.setVisibility(View.VISIBLE);
+                targetView.setVisibility(View.GONE);
+                mIsAnimatingTicker = false;
+            }
+            @Override
+            public void onAnimationCancel(Animator animation) {
+            }
+        });
+    }
+
+    public static boolean isTickerAnimating() {
+        return mIsAnimatingTicker;
+    }
+
+}

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/HeadsUpAppearanceController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/HeadsUpAppearanceController.java
@@ -216,12 +216,13 @@ public class HeadsUpAppearanceController extends ViewController<HeadsUpStatusBar
             boolean animateIsolation = false;
             if (newEntry == null) {
                 // no heads up anymore, lets start the disappear animation
-
+                mNotificationPanelViewController.reTickerView(false);
                 setShown(false);
                 animateIsolation = !isExpanded();
             } else if (previousEntry == null) {
                 // We now have a headsUp and didn't have one before. Let's start the disappear
                 // animation
+                mNotificationPanelViewController.reTickerView(true);
                 setShown(true);
                 animateIsolation = !isExpanded();
             }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelViewController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelViewController.java
@@ -4854,6 +4854,7 @@ public class NotificationPanelViewController extends PanelViewController {
             PendingIntent reTickerIntent = row.getEntry().getSbn().getNotification().contentIntent;
             String mergedContentText = reTickerAppName + " " + reTickerContent;
             mReTickerComebackIcon.setImageDrawable(icon);
+            Drawable dw = mView.getContext().getDrawable(R.drawable.reticker_background);
             boolean reTickerColored = Settings.System.getIntForUser(mView.getContext().getContentResolver(),
                     Settings.System.RETICKER_COLORED, 0, UserHandle.USER_CURRENT) != 0;
             if (reTickerColored) {
@@ -4866,11 +4867,13 @@ public class NotificationPanelViewController extends PanelViewController {
                         col = Color.parseColor(mAppExceptions[i+=1]);
                     }
                 }
-                Drawable dw = mView.getContext().getDrawable(R.drawable.reticker_background);
                 dw.setTint(col);
-                mReTickerComeback.setBackground(dw);
+            } else {
+                dw.setTintList(null);
             }
+            mReTickerComeback.setBackground(dw);
             mReTickerContentTV.setText(mergedContentText);
+            mReTickerContentTV.setTextAppearance(mView.getContext(), R.style.TextAppearance_Notifications_reTicker);
             mReTickerContentTV.setSelected(true);
             RetickerAnimations.doBounceAnimationIn(mReTickerComeback);
             mReTickerComeback.setOnClickListener(v -> {
@@ -4903,14 +4906,6 @@ public class NotificationPanelViewController extends PanelViewController {
         } else {
             mReTickerComeback.getViewTreeObserver().removeOnComputeInternalInsetsListener(mInsetsListener);
         }
-    }
-
-    public void reTickerViewUpdate() {
-        boolean reTickerStatus = Settings.System.getIntForUser(mView.getContext().getContentResolver(),
-                Settings.System.RETICKER_STATUS, 0, UserHandle.USER_CURRENT) != 0;
-        if (reTickerStatus) return;
-        if (mReTickerComeback != null) mReTickerComeback.setBackground(mView.getContext().getDrawable(R.drawable.reticker_background));
-        if (mReTickerContentTV != null) mReTickerContentTV.setTextAppearance(mView.getContext(), R.style.TextAppearance_Notifications_reTicker);
     }
 
     public void reTickerDismissal() {

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelViewController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelViewController.java
@@ -290,6 +290,10 @@ public class NotificationPanelViewController extends PanelViewController {
 
     private static final String STATUS_BAR_QUICK_QS_PULLDOWN = Settings.Secure.STATUS_BAR_QUICK_QS_PULLDOWN;
     private static final String DOUBLE_TAP_SLEEP_GESTURE = Settings.Secure.DOUBLE_TAP_SLEEP_GESTURE;
+    private static final String RETICKER_STATUS =
+            "system:" + Settings.System.RETICKER_STATUS;
+    private static final String RETICKER_COLORED =
+            "system:" + Settings.System.RETICKER_COLORED;
 
     private static final Rect M_DUMMY_DIRTY_RECT = new Rect(0, 0, 1, 1);
     private static final Rect EMPTY_RECT = new Rect();
@@ -648,6 +652,8 @@ public class NotificationPanelViewController extends PanelViewController {
     private ImageView mReTickerComebackIcon;
     private TextView mReTickerContentTV;
     private NotificationStackScrollLayout mNotificationStackScroller;
+    private boolean mReTickerStatus;
+    private boolean mReTickerColored;
 
     private View.AccessibilityDelegate mAccessibilityDelegate = new View.AccessibilityDelegate() {
         @Override
@@ -4623,6 +4629,8 @@ public class NotificationPanelViewController extends PanelViewController {
             mConfigurationController.addCallback(mConfigurationListener);
             mTunerService.addTunable(this, STATUS_BAR_QUICK_QS_PULLDOWN);
             mTunerService.addTunable(this, DOUBLE_TAP_SLEEP_GESTURE);
+            mTunerService.addTunable(this, RETICKER_STATUS);
+            mTunerService.addTunable(this, RETICKER_COLORED);
             // Theme might have changed between inflating this view and attaching it to the
             // window, so
             // force a call to onThemeChanged
@@ -4652,6 +4660,14 @@ public class NotificationPanelViewController extends PanelViewController {
                     break;
                 case DOUBLE_TAP_SLEEP_GESTURE:
                     mDoubleTapToSleepEnabled =
+                            TunerService.parseIntegerSwitch(newValue, false);
+                    break;
+                case RETICKER_STATUS:
+                    mReTickerStatus =
+                            TunerService.parseIntegerSwitch(newValue, false);
+                    break;
+                case RETICKER_COLORED:
+                    mReTickerColored =
                             TunerService.parseIntegerSwitch(newValue, false);
                     break;
                 default:
@@ -4833,9 +4849,7 @@ public class NotificationPanelViewController extends PanelViewController {
     /* reTicker */
 
     public void reTickerView(boolean visibility) {
-        boolean reTickerStatus = Settings.System.getIntForUser(mView.getContext().getContentResolver(),
-                Settings.System.RETICKER_STATUS, 0, UserHandle.USER_CURRENT) != 0;
-        if (!reTickerStatus) return;
+        if (!mReTickerStatus) return;
         if (visibility && mReTickerComeback.getVisibility() == View.VISIBLE) {
             reTickerDismissal();
         }
@@ -4862,9 +4876,7 @@ public class NotificationPanelViewController extends PanelViewController {
             String mergedContentText = reTickerAppName + " " + reTickerContent;
             mReTickerComebackIcon.setImageDrawable(icon);
             Drawable dw = mView.getContext().getDrawable(R.drawable.reticker_background);
-            boolean reTickerColored = Settings.System.getIntForUser(mView.getContext().getContentResolver(),
-                    Settings.System.RETICKER_COLORED, 0, UserHandle.USER_CURRENT) != 0;
-            if (reTickerColored) {
+            if (mReTickerColored) {
                 int col;
                 col = row.getEntry().getSbn().getNotification().color;
                 mAppExceptions = mView.getContext().getResources().getStringArray(R.array.app_exceptions);
@@ -4900,9 +4912,7 @@ public class NotificationPanelViewController extends PanelViewController {
     }
 
     private void reTickerViewVisibility() {
-        boolean reTickerStatus = Settings.System.getIntForUser(mView.getContext().getContentResolver(),
-                Settings.System.RETICKER_STATUS, 0, UserHandle.USER_CURRENT) != 0;
-        if (!reTickerStatus) {
+        if (!mReTickerStatus) {
             reTickerDismissal();
             return;
         }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelViewController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelViewController.java
@@ -46,6 +46,7 @@ import android.animation.AnimatorListenerAdapter;
 import android.animation.ValueAnimator;
 import android.app.ActivityManager;
 import android.app.Fragment;
+import android.app.Notification;
 import android.app.PendingIntent;
 import android.app.StatusBarManager;
 import android.content.ContentResolver;
@@ -74,6 +75,7 @@ import android.os.SystemClock;
 import android.os.UserManager;
 import android.os.VibrationEffect;
 import android.provider.Settings;
+import android.service.notification.StatusBarNotification;
 import android.text.TextUtils;
 import android.transition.ChangeBounds;
 import android.transition.TransitionManager;
@@ -647,7 +649,7 @@ public class NotificationPanelViewController extends PanelViewController {
 
     private Optional<KeyguardUnfoldTransition> mKeyguardUnfoldTransition;
 
-    private String[] mAppExceptions;
+    private final String[] mAppExceptions;
 
     /*Reticker*/
     private LinearLayout mReTickerComeback;
@@ -860,6 +862,7 @@ public class NotificationPanelViewController extends PanelViewController {
         mLockIconViewController = lockIconViewController;
         mUnlockedScreenOffAnimationController = unlockedScreenOffAnimationController;
         mRemoteInputManager = remoteInputManager;
+        mAppExceptions = mResources.getStringArray(R.array.app_exceptions);
 
         int currentMode = navigationModeController.addListener(
                 mode -> mIsGestureNavigation = QuickStepContract.isGesturalMode(mode));
@@ -4855,41 +4858,39 @@ public class NotificationPanelViewController extends PanelViewController {
         if (visibility && mReTickerComeback.getVisibility() == View.VISIBLE) {
             reTickerDismissal();
         }
-        String reTickerContent = "";
-        boolean debug = true;
+        String reTickerContent;
         if (visibility && getExpandedFraction() != 1) {
             mNotificationStackScroller.setVisibility(GONE);
-            ExpandableNotificationRow row = mHeadsUpManager.getTopEntry().getRow();
-            String pkgname = row.getEntry().getSbn().getPackageName();
+            StatusBarNotification sbn = mHeadsUpManager.getTopEntry().getRow().getEntry().getSbn();
+            Notification notification = sbn.getNotification();
+            String pkgname = sbn.getPackageName();
             Drawable icon = null;
             try {
-                if (pkgname.contains("systemui")) {
-                    icon = mView.getContext().getDrawable(row.getEntry().getSbn().getNotification().icon);
+                if (pkgname.equals("com.android.systemui")) {
+                    icon = mView.getContext().getDrawable(notification.icon);
                 } else {
                     icon = mView.getContext().getPackageManager().getApplicationIcon(pkgname);
                 }
             } catch (NameNotFoundException e) {
                 return;
             }
-            String content = row.getEntry().getSbn().getNotification().extras.getString("android.text");
-            if (!TextUtils.isEmpty(content)) {
-                reTickerContent = content;
-            } else {
-                return;
-            }
-            String reTickerAppName = row.getEntry().getSbn().getNotification().extras.getString("android.title");
-            PendingIntent reTickerIntent = row.getEntry().getSbn().getNotification().contentIntent;
+            String content = notification.extras.getString("android.text");
+            if (TextUtils.isEmpty(content)) return;
+            reTickerContent = content;
+            String reTickerAppName = notification.extras.getString("android.title");
+            PendingIntent reTickerIntent = notification.contentIntent;
             String mergedContentText = reTickerAppName + " " + reTickerContent;
             mReTickerComebackIcon.setImageDrawable(icon);
             Drawable dw = mView.getContext().getDrawable(R.drawable.reticker_background);
             if (mReTickerColored) {
-                int col;
-                col = row.getEntry().getSbn().getNotification().color;
-                mAppExceptions = mView.getContext().getResources().getStringArray(R.array.app_exceptions);
-                //check if we need to override the color
-                for (int i = 0; i < mAppExceptions.length; i++) {
-                    if (mAppExceptions[i].contains(pkgname)) {
-                        col = Color.parseColor(mAppExceptions[i += 1]);
+                int col = notification.color;
+                // check if we need to override the color
+                if ((mAppExceptions.length & 1) == 0) {
+                    for (int i = 0; i < mAppExceptions.length; i += 2) {
+                        if (mAppExceptions[i].equals(pkgname)) {
+                            col = Color.parseColor(mAppExceptions[i + 1]);
+                            break;
+                        }
                     }
                 }
                 dw.setTint(col);
@@ -4901,17 +4902,16 @@ public class NotificationPanelViewController extends PanelViewController {
             mReTickerContentTV.setTextAppearance(mView.getContext(), R.style.TextAppearance_Notifications_reTicker);
             mReTickerContentTV.setSelected(true);
             RetickerAnimations.doBounceAnimationIn(mReTickerComeback);
-            mReTickerComeback.setOnClickListener(v -> {
-                try {
-                    if (reTickerIntent != null)
+            if (reTickerIntent != null) {
+                mReTickerComeback.setOnClickListener(v -> {
+                    try {
                         reTickerIntent.send();
-                } catch (PendingIntent.CanceledException e) {
-                }
-                if (reTickerIntent != null) {
+                    } catch (PendingIntent.CanceledException e) {
+                    }
                     RetickerAnimations.doBounceAnimationOut(mReTickerComeback, mNotificationStackScroller);
                     reTickerViewVisibility();
-                }
-            });
+                });
+            }
         } else {
             reTickerDismissal();
         }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelViewController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelViewController.java
@@ -50,6 +50,7 @@ import android.app.PendingIntent;
 import android.app.StatusBarManager;
 import android.content.ContentResolver;
 import android.content.Context;
+import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.ResolveInfo;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -73,6 +74,7 @@ import android.os.SystemClock;
 import android.os.UserManager;
 import android.os.VibrationEffect;
 import android.provider.Settings;
+import android.text.TextUtils;
 import android.transition.ChangeBounds;
 import android.transition.TransitionManager;
 import android.util.Log;
@@ -4866,10 +4868,14 @@ public class NotificationPanelViewController extends PanelViewController {
                 } else {
                     icon = mView.getContext().getPackageManager().getApplicationIcon(pkgname);
                 }
-            } catch (android.content.pm.PackageManager.NameNotFoundException e) {
+            } catch (NameNotFoundException e) {
+                return;
             }
-            if (row.getEntry().getSbn().getNotification().extras.getString("android.text") != null) {
-                reTickerContent = row.getEntry().getSbn().getNotification().extras.getString("android.text");
+            String content = row.getEntry().getSbn().getNotification().extras.getString("android.text");
+            if (!TextUtils.isEmpty(content)) {
+                reTickerContent = content;
+            } else {
+                return;
             }
             String reTickerAppName = row.getEntry().getSbn().getNotification().extras.getString("android.title");
             PendingIntent reTickerIntent = row.getEntry().getSbn().getNotification().contentIntent;
@@ -4881,9 +4887,9 @@ public class NotificationPanelViewController extends PanelViewController {
                 col = row.getEntry().getSbn().getNotification().color;
                 mAppExceptions = mView.getContext().getResources().getStringArray(R.array.app_exceptions);
                 //check if we need to override the color
-                for (int i=0; i < mAppExceptions.length; i++) {
+                for (int i = 0; i < mAppExceptions.length; i++) {
                     if (mAppExceptions[i].contains(pkgname)) {
-                        col = Color.parseColor(mAppExceptions[i+=1]);
+                        col = Color.parseColor(mAppExceptions[i += 1]);
                     }
                 }
                 dw.setTint(col);

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelViewController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelViewController.java
@@ -46,6 +46,7 @@ import android.animation.AnimatorListenerAdapter;
 import android.animation.ValueAnimator;
 import android.app.ActivityManager;
 import android.app.Fragment;
+import android.app.PendingIntent;
 import android.app.StatusBarManager;
 import android.content.ContentResolver;
 import android.content.Context;
@@ -56,6 +57,7 @@ import android.database.ContentObserver;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.ColorFilter;
+import android.graphics.ColorMatrixColorFilter;
 import android.graphics.Insets;
 import android.graphics.Paint;
 import android.graphics.PointF;
@@ -84,11 +86,16 @@ import android.view.ViewGroup;
 import android.view.ViewPropertyAnimator;
 import android.view.ViewStub;
 import android.view.ViewTreeObserver;
+import android.view.ViewTreeObserver.InternalInsetsInfo;
+import android.view.ViewTreeObserver.OnComputeInternalInsetsListener;
 import android.view.WindowInsets;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 import androidx.constraintlayout.widget.ConstraintSet;
@@ -112,6 +119,8 @@ import com.android.keyguard.dagger.KeyguardUserSwitcherComponent;
 import com.android.systemui.DejankUtils;
 import com.android.systemui.Dependency;
 import com.android.systemui.R;
+import com.android.systemui.RetickerAnimations;
+import com.android.systemui.ScreenDecorations;
 import com.android.systemui.animation.ActivityLaunchAnimator;
 import com.android.systemui.animation.Interpolators;
 import com.android.systemui.animation.LaunchAnimator;
@@ -632,6 +641,14 @@ public class NotificationPanelViewController extends PanelViewController {
 
     private Optional<KeyguardUnfoldTransition> mKeyguardUnfoldTransition;
 
+    private String[] mAppExceptions;
+
+    /*Reticker*/
+    private LinearLayout mReTickerComeback;
+    private ImageView mReTickerComebackIcon;
+    private TextView mReTickerContentTV;
+    private NotificationStackScrollLayout mNotificationStackScroller;
+
     private View.AccessibilityDelegate mAccessibilityDelegate = new View.AccessibilityDelegate() {
         @Override
         public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfo info) {
@@ -907,6 +924,11 @@ public class NotificationPanelViewController extends PanelViewController {
         mPreviewContainer = mView.findViewById(R.id.preview_container);
         mKeyguardBottomArea.setPreviewContainer(mPreviewContainer);
         mLastOrientation = mResources.getConfiguration().orientation;
+
+        mReTickerComeback = mView.findViewById(R.id.ticker_comeback);
+        mReTickerComebackIcon = mView.findViewById(R.id.ticker_comeback_icon);
+        mReTickerContentTV = mView.findViewById(R.id.ticker_content);
+        mNotificationStackScroller = mView.findViewById(R.id.notification_stack_scroller);
 
         initBottomArea();
 
@@ -2318,6 +2340,7 @@ public class NotificationPanelViewController extends PanelViewController {
         }
 
         mDepthController.setQsPanelExpansion(qsExpansionFraction);
+        reTickerViewVisibility();
     }
 
     private void onStackYChanged(boolean shouldAnimate) {
@@ -4799,4 +4822,112 @@ public class NotificationPanelViewController extends PanelViewController {
     public PhoneStatusBarView.TouchEventHandler getStatusBarTouchEventHandler() {
         return mStatusBarViewTouchEventHandler;
     }
+
+    /* reTicker */
+
+    public void reTickerView(boolean visibility) {
+        boolean reTickerStatus = Settings.System.getIntForUser(mView.getContext().getContentResolver(),
+                Settings.System.RETICKER_STATUS, 0, UserHandle.USER_CURRENT) != 0;
+        if (!reTickerStatus) return;
+        if (visibility && mReTickerComeback.getVisibility() == View.VISIBLE) {
+            reTickerDismissal();
+        }
+        String reTickerContent = "";
+        boolean debug = true;
+        if (visibility && getExpandedFraction() != 1) {
+            mNotificationStackScroller.setVisibility(GONE);
+            ExpandableNotificationRow row = mHeadsUpManager.getTopEntry().getRow();
+            String pkgname = row.getEntry().getSbn().getPackageName();
+            Drawable icon = null;
+            try {
+                if (pkgname.contains("systemui")) {
+                    icon = mView.getContext().getDrawable(row.getEntry().getSbn().getNotification().icon);
+                } else {
+                    icon = mView.getContext().getPackageManager().getApplicationIcon(pkgname);
+                }
+            } catch (android.content.pm.PackageManager.NameNotFoundException e) {
+            }
+            if (row.getEntry().getSbn().getNotification().extras.getString("android.text") != null) {
+                reTickerContent = row.getEntry().getSbn().getNotification().extras.getString("android.text");
+            }
+            String reTickerAppName = row.getEntry().getSbn().getNotification().extras.getString("android.title");
+            PendingIntent reTickerIntent = row.getEntry().getSbn().getNotification().contentIntent;
+            String mergedContentText = reTickerAppName + " " + reTickerContent;
+            mReTickerComebackIcon.setImageDrawable(icon);
+            boolean reTickerColored = Settings.System.getIntForUser(mView.getContext().getContentResolver(),
+                    Settings.System.RETICKER_COLORED, 0, UserHandle.USER_CURRENT) != 0;
+            if (reTickerColored) {
+                int col;
+                col = row.getEntry().getSbn().getNotification().color;
+                mAppExceptions = mView.getContext().getResources().getStringArray(R.array.app_exceptions);
+                //check if we need to override the color
+                for (int i=0; i < mAppExceptions.length; i++) {
+                    if (mAppExceptions[i].contains(pkgname)) {
+                        col = Color.parseColor(mAppExceptions[i+=1]);
+                    }
+                }
+                Drawable dw = mView.getContext().getDrawable(R.drawable.reticker_background);
+                dw.setTint(col);
+                mReTickerComeback.setBackground(dw);
+            }
+            mReTickerContentTV.setText(mergedContentText);
+            mReTickerContentTV.setSelected(true);
+            RetickerAnimations.doBounceAnimationIn(mReTickerComeback);
+            mReTickerComeback.setOnClickListener(v -> {
+                try {
+                    if (reTickerIntent != null)
+                        reTickerIntent.send();
+                } catch (PendingIntent.CanceledException e) {
+                }
+                if (reTickerIntent != null) {
+                    RetickerAnimations.doBounceAnimationOut(mReTickerComeback, mNotificationStackScroller);
+                    reTickerViewVisibility();
+                }
+            });
+        } else {
+            reTickerDismissal();
+        }
+    }
+
+    private void reTickerViewVisibility() {
+        boolean reTickerStatus = Settings.System.getIntForUser(mView.getContext().getContentResolver(),
+                Settings.System.RETICKER_STATUS, 0, UserHandle.USER_CURRENT) != 0;
+        if (!reTickerStatus) {
+            reTickerDismissal();
+            return;
+        }
+        mNotificationStackScroller.setVisibility(getExpandedFraction() == 0 ? View.GONE : View.VISIBLE);
+        if (getExpandedFraction() > 0) mReTickerComeback.setVisibility(View.GONE);
+        if (mReTickerComeback.getVisibility() == View.VISIBLE) {
+            mReTickerComeback.getViewTreeObserver().addOnComputeInternalInsetsListener(mInsetsListener);
+        } else {
+            mReTickerComeback.getViewTreeObserver().removeOnComputeInternalInsetsListener(mInsetsListener);
+        }
+    }
+
+    public void reTickerViewUpdate() {
+        boolean reTickerStatus = Settings.System.getIntForUser(mView.getContext().getContentResolver(),
+                Settings.System.RETICKER_STATUS, 0, UserHandle.USER_CURRENT) != 0;
+        if (reTickerStatus) return;
+        if (mReTickerComeback != null) mReTickerComeback.setBackground(mView.getContext().getDrawable(R.drawable.reticker_background));
+        if (mReTickerContentTV != null) mReTickerContentTV.setTextAppearance(mView.getContext(), R.style.TextAppearance_Notifications_reTicker);
+    }
+
+    public void reTickerDismissal() {
+        RetickerAnimations.doBounceAnimationOut(mReTickerComeback, mNotificationStackScroller);
+        mReTickerComeback.getViewTreeObserver().removeOnComputeInternalInsetsListener(mInsetsListener);
+    }
+
+    private final OnComputeInternalInsetsListener mInsetsListener = internalInsetsInfo -> {
+        internalInsetsInfo.touchableRegion.setEmpty();
+        internalInsetsInfo.setTouchableInsets(InternalInsetsInfo.TOUCHABLE_INSETS_REGION);
+        int[] mainLocation = new int[2];
+        mReTickerComeback.getLocationOnScreen(mainLocation);
+        internalInsetsInfo.touchableRegion.set(new Region(
+            mainLocation[0],
+            mainLocation[1],
+            mainLocation[0] + mReTickerComeback.getWidth(),
+            mainLocation[1] + mReTickerComeback.getHeight()
+        ));
+    };
 }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelViewController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelViewController.java
@@ -4645,10 +4645,17 @@ public class NotificationPanelViewController extends PanelViewController {
 
         @Override
         public void onTuningChanged(String key, String newValue) {
-            if (STATUS_BAR_QUICK_QS_PULLDOWN.equals(key)) {
-                mOneFingerQuickSettingsIntercept = TunerService.parseInteger(newValue, 0);
-            } else if (DOUBLE_TAP_SLEEP_GESTURE.equals(key)) {
-                mDoubleTapToSleepEnabled = TunerService.parseIntegerSwitch(newValue, false);
+            switch (key) {
+                case STATUS_BAR_QUICK_QS_PULLDOWN:
+                    mOneFingerQuickSettingsIntercept =
+                            TunerService.parseInteger(newValue, 0);
+                    break;
+                case DOUBLE_TAP_SLEEP_GESTURE:
+                    mDoubleTapToSleepEnabled =
+                            TunerService.parseIntegerSwitch(newValue, false);
+                    break;
+                default:
+                    break;
             }
         }
     }

--- a/packages/SystemUI/src/com/android/systemui/tuner/TunerServiceImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/tuner/TunerServiceImpl.java
@@ -160,31 +160,64 @@ public class TunerServiceImpl extends TunerService {
         setValue(TUNER_VERSION, newVersion);
     }
 
+    private boolean isSystem(String key) {
+        return key.startsWith("system:");
+    }
+
+    private String chomp(String key) {
+        return key.replaceFirst("^(system):", "");
+    }
+
     @Override
     public String getValue(String setting) {
-        return Settings.Secure.getStringForUser(mContentResolver, setting, mCurrentUser);
+        if (isSystem(setting)) {
+            return Settings.System.getStringForUser(
+                    mContentResolver, chomp(setting), mCurrentUser);
+        } else {
+            return Settings.Secure.getStringForUser(mContentResolver, setting, mCurrentUser);
+        }
     }
 
     @Override
     public void setValue(String setting, String value) {
-         Settings.Secure.putStringForUser(mContentResolver, setting, value, mCurrentUser);
+        if (isSystem(setting)) {
+            Settings.System.putStringForUser(
+                    mContentResolver, chomp(setting), value, mCurrentUser);
+        } else {
+            Settings.Secure.putStringForUser(mContentResolver, setting, value, mCurrentUser);
+        }
     }
 
     @Override
     public int getValue(String setting, int def) {
-        return Settings.Secure.getIntForUser(mContentResolver, setting, def, mCurrentUser);
+        if (isSystem(setting)) {
+            return Settings.System.getIntForUser(
+                    mContentResolver, chomp(setting), def, mCurrentUser);
+        } else {
+            return Settings.Secure.getIntForUser(mContentResolver, setting, def, mCurrentUser);
+        }
     }
 
     @Override
     public String getValue(String setting, String def) {
-        String ret = Secure.getStringForUser(mContentResolver, setting, mCurrentUser);
+        String ret;
+        if (isSystem(setting)) {
+            ret = Settings.System.getStringForUser(
+                    mContentResolver, chomp(setting), mCurrentUser);
+        } else {
+            ret = Secure.getStringForUser(mContentResolver, setting, mCurrentUser);
+        }
         if (ret == null) return def;
         return ret;
     }
 
     @Override
     public void setValue(String setting, int value) {
-         Settings.Secure.putIntForUser(mContentResolver, setting, value, mCurrentUser);
+        if (isSystem(setting)) {
+            Settings.System.putIntForUser(mContentResolver, chomp(setting), value, mCurrentUser);
+        } else {
+            Settings.Secure.putIntForUser(mContentResolver, setting, value, mCurrentUser);
+        }
     }
 
     @Override
@@ -203,14 +236,18 @@ public class TunerServiceImpl extends TunerService {
             mTunables.add(tunable);
             mLeakDetector.trackCollection(mTunables, "TunerService.mTunables");
         }
-        Uri uri = Settings.Secure.getUriFor(key);
+        final Uri uri;
+        if (isSystem(key)) {
+            uri = Settings.System.getUriFor(chomp(key));
+        } else {
+            uri = Settings.Secure.getUriFor(key);
+        }
         if (!mListeningUris.containsKey(uri)) {
             mListeningUris.put(uri, key);
             mContentResolver.registerContentObserver(uri, false, mObserver, mCurrentUser);
         }
         // Send the first state.
-        String value = DejankUtils.whitelistIpcs(() -> Settings.Secure
-                .getStringForUser(mContentResolver, key, mCurrentUser));
+        String value = DejankUtils.whitelistIpcs(() -> getValue(key));
         tunable.onTuningChanged(key, value);
     }
 
@@ -240,7 +277,7 @@ public class TunerServiceImpl extends TunerService {
         if (tunables == null) {
             return;
         }
-        String value = Settings.Secure.getStringForUser(mContentResolver, key, mCurrentUser);
+        String value = getValue(key);
         for (Tunable tunable : tunables) {
             if (tunable != null) {
                 tunable.onTuningChanged(key, value);
@@ -253,8 +290,7 @@ public class TunerServiceImpl extends TunerService {
             if (ArrayUtils.contains(RESET_EXCEPTION_LIST, key)) {
                 continue;
             }
-            String value = Settings.Secure.getStringForUser(mContentResolver, key,
-                    mCurrentUser);
+            String value = getValue(key);
             for (Tunable tunable : mTunableLookup.get(key)) {
                 if (tunable != null) {
                     tunable.onTuningChanged(key, value);

--- a/packages/SystemUI/src/com/android/systemui/tuner/TunerServiceImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/tuner/TunerServiceImpl.java
@@ -242,7 +242,9 @@ public class TunerServiceImpl extends TunerService {
         }
         String value = Settings.Secure.getStringForUser(mContentResolver, key, mCurrentUser);
         for (Tunable tunable : tunables) {
-            tunable.onTuningChanged(key, value);
+            if (tunable != null) {
+                tunable.onTuningChanged(key, value);
+            }
         }
     }
 
@@ -254,7 +256,9 @@ public class TunerServiceImpl extends TunerService {
             String value = Settings.Secure.getStringForUser(mContentResolver, key,
                     mCurrentUser);
             for (Tunable tunable : mTunableLookup.get(key)) {
-                tunable.onTuningChanged(key, value);
+                if (tunable != null) {
+                    tunable.onTuningChanged(key, value);
+                }
             }
         }
     }

--- a/packages/SystemUI/src/com/android/systemui/tuner/TunerServiceImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/tuner/TunerServiceImpl.java
@@ -248,6 +248,9 @@ public class TunerServiceImpl extends TunerService {
 
     private void reloadAll() {
         for (String key : mTunableLookup.keySet()) {
+            if (ArrayUtils.contains(RESET_EXCEPTION_LIST, key)) {
+                continue;
+            }
             String value = Settings.Secure.getStringForUser(mContentResolver, key,
                     mCurrentUser);
             for (Tunable tunable : mTunableLookup.get(key)) {
@@ -268,9 +271,6 @@ public class TunerServiceImpl extends TunerService {
 
         // A couple special cases.
         for (String key : mTunableLookup.keySet()) {
-            if (ArrayUtils.contains(RESET_EXCEPTION_LIST, key)) {
-                continue;
-            }
             Settings.Secure.putStringForUser(mContentResolver, key, null, user);
         }
     }

--- a/packages/SystemUI/src/com/android/systemui/tuner/TunerServiceImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/tuner/TunerServiceImpl.java
@@ -287,7 +287,7 @@ public class TunerServiceImpl extends TunerService {
 
     private void reloadAll() {
         for (String key : mTunableLookup.keySet()) {
-            if (ArrayUtils.contains(RESET_EXCEPTION_LIST, key)) {
+            if (ArrayUtils.contains(RESET_EXCEPTION_LIST, key) || key.startsWith("system:")) {
                 continue;
             }
             String value = getValue(key);


### PR DESCRIPTION
Add reTicker feature, Which is replacing heads-up notification with slim and less invasive version of redesigned ticker when enabled.
Originally, This feature is developed on [Android 11 based Descendant-XI](https://github.com/Descendant-XI/frameworks_base/commit/6ca0cff0da94d07a14ca8695b7bde5eaea9deef5).

I forward ported/adapted based on Material You theme for A12, and crDroid Android's developer improved by [clean up the commit](https://github.com/crdroidandroid/android_frameworks_base/commit/e44ede735e177d8297cfbfa8b22a21041c229ace).

Required commit is https://github.com/someone5678/android_frameworks_base-kscope/commit/6c4326f7d1af45d2568d538271997d6a62d97705
And other commits are not necessary but improved the feature's code.
Also, using TunerService makes App colored background enabled without SystemUI restart.

Screenshots:
[1] [reTicker](https://ibb.co/xhzNkY9)
[2] [reTicker with App Icon colored background enabled](https://ibb.co/cC2dnBj)